### PR TITLE
Separate mesos master and slave options

### DIFF
--- a/lib/puppet/parser/functions/mesos_hash_parser.rb
+++ b/lib/puppet/parser/functions/mesos_hash_parser.rb
@@ -11,22 +11,25 @@ that is required by create_resources function
         EOS
   ) do |args|
 
-    # Only 1 argument should be passed
-    if args.size < 1 || args.size > 2
+    # Arguments: hash key_prefix [file_prefix]
+      
+    if args.size < 1 || args.size > 3
       raise(Puppet::ParseError, "mesos_hash_parser(): Wrong number of args " + "given (#{args.size} for 1)")
     end
 
-    # The argument should be a Hash
     if args[0].class != Hash
       raise(Puppet::ParseError, "mesos_hash_parser() accepts a Hash, you passed a " + args[0].class)
     end
 
     res = {}
-    prefix = args[1] if args.size == 2
+    key_prefix = args[1] if args.size >= 2
+    file_prefix = args[2] if args.size == 3
     args[0].each do |key, val|
-      key = "#{prefix}_#{key}" if prefix
+      file = file_prefix ? "#{file_prefix}_#{key}" : key
+      key = "#{key_prefix}_#{key}" if key_prefix
       res[key] = {
-        "value" => val
+          "value" => val,
+          "file" => file,
       }
     end
     res

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -59,7 +59,7 @@ class mesos::master(
   }
 
   create_resources(mesos::property,
-    mesos_hash_parser($options),
+    mesos_hash_parser($options, 'master'),
     {
       dir     => $conf_dir,
       service => Service['mesos-master'],

--- a/manifests/slave.pp
+++ b/manifests/slave.pp
@@ -96,7 +96,7 @@ class mesos::slave (
 
   # stores properties in file structure
   create_resources(mesos::property,
-    mesos_hash_parser($cgroups, 'cgroups'),
+    mesos_hash_parser($cgroups, 'slave', 'cgroups'),
     {
       dir     => $conf_dir,
       service => Service['mesos-slave'],
@@ -127,7 +127,7 @@ class mesos::slave (
   }
 
   create_resources(mesos::property,
-    mesos_hash_parser($merged_options),
+    mesos_hash_parser($merged_options, 'slave'),
     {
       dir     => $conf_dir,
       service => Service['mesos-slave'],
@@ -135,7 +135,7 @@ class mesos::slave (
   )
 
   create_resources(mesos::property,
-    mesos_hash_parser($resources),
+    mesos_hash_parser($resources, 'resources'),
     {
       dir     => "${conf_dir}/resources",
       service => Service['mesos-slave'],
@@ -143,7 +143,7 @@ class mesos::slave (
   )
 
   create_resources(mesos::property,
-    mesos_hash_parser($attributes),
+    mesos_hash_parser($attributes, 'attributes'),
     {
       dir     => "${conf_dir}/attributes",
       service => Service['mesos-slave'],

--- a/spec/functions/mesos_hash_parser_spec.rb
+++ b/spec/functions/mesos_hash_parser_spec.rb
@@ -13,12 +13,13 @@ describe 'mesos_hash_parser' do
       subject.should run.with_params(param).and_return({
           'isolation' => {
             'value' => 'cgroups',
+            'file' => 'isolation',                                                   
           }
         })
     end
 
     it 'should raise an error if run with extra arguments' do
-      subject.should run.with_params(1, 2, 3).and_raise_error(Puppet::ParseError)
+      subject.should run.with_params(1, 2, 3, 4).and_raise_error(Puppet::ParseError)
     end
   end
 
@@ -31,6 +32,20 @@ describe 'mesos_hash_parser' do
       subject.should run.with_params(param, 'cg').and_return({
           'cg_root' => {
             'value' => '/cgroups',
+            'file' => 'root',                                                         
+          }
+        })
+    end
+
+    it 'should prefix files' do
+      param = {
+        'root' => '/cgroups',
+      }
+
+      subject.should run.with_params(param, 'cg', 'cg').and_return({
+          'cg_root' => {
+            'value' => '/cgroups',
+            'file' => 'cg_root',
           }
         })
     end


### PR DESCRIPTION
There is a conflict between mesos::property resource names when
mesos::master::options and mesos::slave::options are used on same
machine. The file is different since the directory is different but
the resource name is just the key. There is also a potential conflict
between attributes and resources names.

The solution is to add prefix to name like is done for the static
properties. This involves adding parameter to mesos_hash_parser
function.
